### PR TITLE
Fixed crashing script on macOS because of chown with a non-existent user

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -17,5 +17,8 @@ if [ "$1" = "--restore-db" ];
 fi
 
 # We need to chown folders as they are docker's volumes
-sudo chown -R www-data var/media
-sudo chown -R root var/backup
+# (do not work on OSX, hence the test)
+if ! uname -a | grep Darwin > /dev/null; then
+  sudo chown -R www-data var/media
+  sudo chown -R root var/backup
+fi


### PR DESCRIPTION
The user `www-data` doesn't exist on macOS, or at least make the `pull.sh` script crash. Nothing critical as it's the last commands.