### PR TITLE
fix(setup_lib.sh): Exit when any command fails

### DIFF
--- a/build/local/setup_lib.sh
+++ b/build/local/setup_lib.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit when any command fails
+set -e
+
 for module in `ls /srv/lib/`; do
 	cd /srv/lib/$module
 	if [ -f 'requirements.txt' ]; then

--- a/build/local/setup_lib.sh
+++ b/build/local/setup_lib.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Exit when any command fails
+# We need to stop build if pip fails
 set -e
 
 for module in `ls /srv/lib/`; do


### PR DESCRIPTION
Stop docker build when dependencies are not satisfied.

Before this PR, pip may fails to install dependencies and Docker build would work. This lead to a not working image.

Dockerfile
```
FROM python:3.6-stretch

WORKDIR /app

# Upgrade to latest pip version
RUN pip install -U pip

COPY lib /app/lib
COPY ./setup_lib.sh /app
RUN bash ./setup_lib.sh
```

lib/a/requirements.txt
```
# This should is incompatible
django-celery==3.3.1
celery==4.2.2
```

lib/b/requirements.txt
```
markdown
```

